### PR TITLE
Adjustments to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Both schemes cover an identical (and broad) set of syntax scopes, current with B
 
 ## Installation
 
-1. Put these in the "Color Schemes" folder for BBEdit.
+1. Put these in BBEdit's "Color Schemes" support folder. (You can get there by choosing the folder name from the "Folders" submenu on the BBEdit application menu.)
 2. Select one of them in the "Text Colors" preference pane.
 3. There is no step three.
 


### PR DESCRIPTION
Amplified step one to specify the BBEdit support folder and provide
instructions for getting there, because at least one person thought it
was OK to crack open the application package and modify the built-in
color schemes. (This invalidated the application's code signature and
triggered the tamper warning.)